### PR TITLE
Fix native loaders when processing ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.21"
+version = "0.9.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1981,33 +1981,33 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-api"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
  "solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-bpf-loader-program"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-bpf-loader-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-bpf-loader-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
 name = "solana-budget-api"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2016,24 +2016,24 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
 name = "solana-budget-program"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-budget-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-budget-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
 name = "solana-chacha-sys"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2041,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "solana-cli"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2055,30 +2055,30 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty-hex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-budget-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-client 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-config-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-drone 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-netutil 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-runtime 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-stake-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-storage-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-vote-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-vote-signer 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-budget-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-client 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-config-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-drone 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-netutil 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-runtime 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-stake-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-storage-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-vote-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-vote-signer 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-client"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2086,30 +2086,30 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-netutil 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-netutil 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
 name = "solana-config-api"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
 name = "solana-core"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2141,26 +2141,26 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-budget-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-budget-program 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-chacha-sys 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-client 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-drone 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-budget-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-budget-program 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-chacha-sys 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-client 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-drone 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
  "solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-measure 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-merkle-tree 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-metrics 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-netutil 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-rayon-threadlimit 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-measure 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-merkle-tree 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-metrics 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-netutil 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-rayon-threadlimit 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
  "solana-reed-solomon-erasure 4.0.1-3 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-runtime 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-stake-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-storage-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-storage-program 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-vote-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-vote-signer 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-runtime 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-stake-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-storage-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-storage-program 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-vote-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-vote-signer 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
  "symlink 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "solana-crate-features"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2187,7 +2187,7 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2197,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "solana-drone"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2206,9 +2206,9 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-metrics 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-metrics 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2229,7 +2229,7 @@ dependencies = [
 [[package]]
 name = "solana-logger"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2239,36 +2239,36 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
 name = "solana-merkle-tree"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
 name = "solana-metrics"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
  "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-netutil"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2279,7 +2279,7 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2306,7 +2306,7 @@ dependencies = [
 [[package]]
 name = "solana-runtime"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2324,18 +2324,18 @@ dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-bpf-loader-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-bpf-loader-program 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-measure 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-metrics 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-rayon-threadlimit 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-stake-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-stake-program 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-storage-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-vote-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-vote-program 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-bpf-loader-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-bpf-loader-program 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-measure 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-metrics 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-rayon-threadlimit 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-stake-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-stake-program 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-storage-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-vote-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-vote-program 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
  "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2343,7 +2343,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2364,16 +2364,16 @@ dependencies = [
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-crate-features 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-crate-features 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
  "solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "solana-stake-api"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2382,28 +2382,28 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-config-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-metrics 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-vote-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-config-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-metrics 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-vote-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
 name = "solana-stake-program"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-stake-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-stake-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
 name = "solana-storage-api"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2413,19 +2413,19 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
 name = "solana-storage-program"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-storage-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-storage-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
@@ -2434,19 +2434,19 @@ version = "1.0.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-cli 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-core 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-runtime 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-stake-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-vote-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-cli 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-core 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-runtime 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-stake-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-vote-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
 name = "solana-vote-api"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2454,26 +2454,26 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-metrics 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-metrics 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
 name = "solana-vote-program"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-vote-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-vote-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
 name = "solana-vote-signer"
 version = "0.20.0"
-source = "git+https://github.com/solana-labs/solana?rev=322fcea6#322fcea6e51a600d8cfcad3f68c4866c094f553c"
+source = "git+https://github.com/jstarry/solana?branch=tds-winner-tool#5883ed8563429244ae4e18d135166e3ce2803a94"
 dependencies = [
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2483,8 +2483,8 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "solana-metrics 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
- "solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)",
+ "solana-metrics 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
+ "solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)",
 ]
 
 [[package]]
@@ -3417,7 +3417,7 @@ dependencies = [
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum reqwest 0.9.21 (registry+https://github.com/rust-lang/crates.io-index)" = "02b7e953e14c6f3102b7e8d1f1ee3abf5ecee80b427f5565c9389835cecae95c"
+"checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
 "checksum rgb 0.8.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2089e4031214d129e201f8c3c8c2fe97cd7322478a0d1cdf78e7029b0042efdb"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
 "checksum rocksdb 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1651697fefd273bfb4fd69466cc2a9d20de557a0213b97233b22b5e95924b5e"
@@ -3443,34 +3443,34 @@ dependencies = [
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
-"checksum solana-bpf-loader-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-bpf-loader-program 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-budget-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-budget-program 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-chacha-sys 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-cli 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-client 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-config-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-core 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-crate-features 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-drone 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
+"checksum solana-bpf-loader-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-bpf-loader-program 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-budget-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-budget-program 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-chacha-sys 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-cli 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-client 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-config-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-core 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-crate-features 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-drone 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
 "checksum solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c21f9d5aa62959872194dfd086feb4e8efec1c2589d27e6a0339904759e99fc"
-"checksum solana-logger 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-measure 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-merkle-tree 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-metrics 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-netutil 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-rayon-threadlimit 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
+"checksum solana-logger 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-measure 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-merkle-tree 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-metrics 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-netutil 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-rayon-threadlimit 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
 "checksum solana-reed-solomon-erasure 4.0.1-3 (registry+https://github.com/rust-lang/crates.io-index)" = "d5b3ab3f4dd12af687a7d0d0ee73299cbc06ed3aada42dccac26fe243e73399e"
-"checksum solana-runtime 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-sdk 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-stake-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-stake-program 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-storage-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-storage-program 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-vote-api 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-vote-program 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
-"checksum solana-vote-signer 0.20.0 (git+https://github.com/solana-labs/solana?rev=322fcea6)" = "<none>"
+"checksum solana-runtime 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-sdk 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-stake-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-stake-program 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-storage-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-storage-program 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-vote-api 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-vote-program 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
+"checksum solana-vote-signer 0.20.0 (git+https://github.com/jstarry/solana?branch=tds-winner-tool)" = "<none>"
 "checksum solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "cb45776e861c7a71ed3ccb629c076889dc91a9ba7c1e58e44f8c7b9f916f07c9"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"

--- a/winner-tool/Cargo.toml
+++ b/winner-tool/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2018"
 name = "solana-tds-winner-tool"
 description = "Solana Tour de SOL winner tool"
 version = "1.0.0"
-repository = "https://github.com/solana-labs/solana"
+repository = "https://github.com/solana-labs/tour-de-sol"
 license = "Apache-2.0"
 homepage = "https://solana.com/tds"
 
@@ -12,10 +12,10 @@ homepage = "https://solana.com/tds"
 clap = "2.33.0"
 log = "0.4.8"
 # Pinning versions until the next solana release (0.20)
-solana-cli = { git = "https://github.com/solana-labs/solana", rev = "322fcea6" }
-solana-core = { git = "https://github.com/solana-labs/solana", rev = "322fcea6" }
-solana-logger = { git = "https://github.com/solana-labs/solana", rev = "322fcea6" }
-solana-runtime = { git = "https://github.com/solana-labs/solana", rev = "322fcea6" }
-solana-sdk = { git = "https://github.com/solana-labs/solana", rev = "322fcea6" }
-solana-stake-api = { git = "https://github.com/solana-labs/solana", rev = "322fcea6" }
-solana-vote-api = { git = "https://github.com/solana-labs/solana", rev = "322fcea6" }
+solana-cli = { git = "https://github.com/jstarry/solana", branch = "tds-winner-tool" }
+solana-core = { git = "https://github.com/jstarry/solana", branch = "tds-winner-tool" }
+solana-logger = { git = "https://github.com/jstarry/solana", branch = "tds-winner-tool" }
+solana-runtime = { git = "https://github.com/jstarry/solana", branch = "tds-winner-tool" }
+solana-sdk = { git = "https://github.com/jstarry/solana", branch = "tds-winner-tool" }
+solana-stake-api = { git = "https://github.com/jstarry/solana", branch = "tds-winner-tool" }
+solana-vote-api = { git = "https://github.com/jstarry/solana", branch = "tds-winner-tool" }

--- a/winner-tool/src/main.rs
+++ b/winner-tool/src/main.rs
@@ -116,10 +116,25 @@ fn main() {
         })
     };
 
+    // Native loaders do not work when runtime is a git or crates.io dependency
+    let new_bank_callback = {
+        Arc::new(move |bank: &mut Bank| {
+            bank.add_instruction_processor(
+                solana_stake_api::id(),
+                solana_stake_api::stake_instruction::process_instruction,
+            );
+            bank.add_instruction_processor(
+                solana_vote_api::id(),
+                solana_vote_api::vote_instruction::process_instruction,
+            );
+        })
+    };
+
     let opts = ProcessOptions {
         verify_ledger: false,
         dev_halt_at_slot: final_slot,
         full_leader_cache: true,
+        new_bank_callback: Some(new_bank_callback),
         entry_callback: Some(entry_callback),
         override_num_threads: Some(1),
     };


### PR DESCRIPTION
#### Problem
Native loaders do not work properly when the `solana-runtime` dependency is a git or crates.io dependency (See here for details: https://github.com/solana-labs/solana/issues/5966)

#### Solution
* Add a callback to modify each new bank to have instruction processors for vote and stake transactions

Depends On: https://github.com/solana-labs/solana/pull/6383