### PR TITLE
Ramp TPS incrementally in a loop

### DIFF
--- a/README-internal.md
+++ b/README-internal.md
@@ -120,6 +120,8 @@ export SLACK_CHANNEL_ID=
 $ cargo run -p solana-ramp-tps -- -n $NET_VALIDATOR0_IP \
   --net-dir <solana/net> \
   --round-minutes 15 \
+  --tps-baseline 5000 \
+  --tps-increment 5000 \
   --mint-keypair-path <mint_keypair.json>
 ```
 
@@ -138,6 +140,8 @@ $ cargo run -p solana-ramp-tps -- -n $NET_VALIDATOR0_IP \
   --net-dir <solana/net> \
   --round <START ROUND> \
   --round-minutes 15 \
+  --tps-baseline 5000 \
+  --tps-increment 5000 \
   --stake-activation-epoch <LAST STAKE ACTIVATION EPOCH> \
   --mint-keypair-path <mint_keypair.json>
 ```

--- a/bench-tps.sh
+++ b/bench-tps.sh
@@ -18,6 +18,10 @@ if [[ -n $remote ]]; then
   exec 2>&1
   PATH=$PATH:.cargo/bin/
   killall solana-bench-tps || true
+
+  if [[ $txCount = 0 ]]; then
+    exit 0
+  fi
 fi
 
 scp -o "ConnectTimeout=20" -o "BatchMode=yes" \

--- a/ramp-tps/src/main.rs
+++ b/ramp-tps/src/main.rs
@@ -19,22 +19,10 @@ const NUM_BENCH_CLIENTS: usize = 2;
 const TDS_ENTRYPOINT: &str = "tds.solana.com";
 const TMP_LEDGER_PATH: &str = ".tmp/ledger";
 const TPS_ROUND_INCREMENT: u64 = 5000;
-const INITIAL_SOL_BALANCE: u64 = 1;
 
 // TPS increments linearly each round
-// Gift will double the staked lamports each round and assume that validators start with 1 SOL.
-//   - Award 1 SOL after Round 1
-//   - Award 2 SOL after Round 2
-//   - Award 4 SOL after Round 3
-fn tps_params(tps_round: u32) -> (u64, u64) {
-    let tps = u64::from(tps_round) * TPS_ROUND_INCREMENT;
-    let gift = if tps_round > 1 {
-        INITIAL_SOL_BALANCE * 2u64.pow(tps_round - 2)
-    } else {
-        0
-    };
-
-    (tps, gift)
+fn tps_for_round(tps_round: u32) -> u64 {
+    u64::from(tps_round) * TPS_ROUND_INCREMENT
 }
 
 fn main() {
@@ -130,7 +118,7 @@ fn main() {
 
     // Start bench-tps
     loop {
-        let (tps, _next_gift) = tps_params(tps_round);
+        let tps = tps_for_round(tps_round);
         info!("Starting round {} with {} TPS", tps_round, tps);
         info!(
             "Run bench-tps for {} minutes",

--- a/ramp-tps/src/main.rs
+++ b/ramp-tps/src/main.rs
@@ -21,10 +21,15 @@ const TMP_LEDGER_PATH: &str = ".tmp/ledger";
 const TPS_ROUND_INCREMENT: u64 = 5000;
 const INITIAL_SOL_BALANCE: u64 = 1;
 
+// TPS increments linearly each round
+// Gift will double the staked lamports each round and assume that validators start with 1 SOL.
+//   - Award 1 SOL after Round 1
+//   - Award 2 SOL after Round 2
+//   - Award 4 SOL after Round 3
 fn tps_params(tps_round: u32) -> (u64, u64) {
     let tps = u64::from(tps_round) * TPS_ROUND_INCREMENT;
     let gift = if tps_round > 1 {
-        INITIAL_SOL_BALANCE * 2u64.pow(tps_round - 1)
+        INITIAL_SOL_BALANCE * 2u64.pow(tps_round - 2)
     } else {
         0
     };

--- a/ramp-tps/src/main.rs
+++ b/ramp-tps/src/main.rs
@@ -124,13 +124,14 @@ fn main() {
             "Run bench-tps for {} minutes",
             round_duration.as_secs() / 60
         );
+        let client_tps = tps / NUM_BENCH_CLIENTS as u64;
         for client_id in 0..NUM_BENCH_CLIENTS {
             Command::new("bash")
                 .args(&[
                     "wrapper-bench-tps.sh",
                     &net_dir,
                     &client_id.to_string(),
-                    &tps.to_string(),
+                    &client_tps.to_string(),
                 ])
                 .spawn()
                 .unwrap();

--- a/ramp-tps/src/main.rs
+++ b/ramp-tps/src/main.rs
@@ -137,6 +137,17 @@ fn main() {
                 .unwrap();
         }
         sleep(round_duration);
+        for client_id in 0..NUM_BENCH_CLIENTS {
+            Command::new("bash")
+                .args(&[
+                    "wrapper-bench-tps.sh",
+                    &net_dir,
+                    &client_id.to_string(),
+                    "0", // Setting txCount to 0 will kill bench-tps
+                ])
+                .spawn()
+                .unwrap();
+        }
 
         tps_round += 1;
 

--- a/ramp-tps/src/main.rs
+++ b/ramp-tps/src/main.rs
@@ -54,8 +54,8 @@ fn main() {
                 .help("The round of TPS ramp up (round 1: 5000, round 2: 10000, etc.)"),
         )
         .arg(
-            Arg::with_name("round_mins")
-                .long("round-mins")
+            Arg::with_name("round_minutes")
+                .long("round-minutes")
                 .value_name("NUM")
                 .takes_value(true)
                 .default_value("60")
@@ -76,7 +76,7 @@ fn main() {
     let net_dir = value_t_or_exit!(matches, "net_dir", String);
     let mut tps_round = value_t_or_exit!(matches, "round", u32).max(1);
     let round_duration =
-        Duration::from_secs(value_t_or_exit!(matches, "round_mins", u64).max(1) * 60);
+        Duration::from_secs(value_t_or_exit!(matches, "round_minutes", u64).max(1) * 60);
     let tmp_ledger_path = PathBuf::from(TMP_LEDGER_PATH);
     let _ = fs::remove_dir_all(&tmp_ledger_path);
     fs::create_dir_all(&tmp_ledger_path).expect("failed to create temp ledger path");

--- a/ramp-tps/src/main.rs
+++ b/ramp-tps/src/main.rs
@@ -144,7 +144,7 @@ fn main() {
         info!("Current epoch info: {:?}", &epoch_info);
         let current_epoch = epoch_info.epoch;
         stake::wait_for_activation(
-            current_epoch + 2,
+            current_epoch + 1,
             epoch_info,
             &rpc_client,
             &stake_config,

--- a/ramp-tps/src/stake.rs
+++ b/ramp-tps/src/stake.rs
@@ -1,5 +1,5 @@
 use crate::utils::sleep_n_slots;
-use log::{debug, info, warn};
+use log::*;
 use solana_client::rpc_client::RpcClient;
 use solana_client::rpc_request::RpcEpochInfo;
 use solana_sdk::genesis_block::GenesisBlock;

--- a/ramp-tps/src/stake.rs
+++ b/ramp-tps/src/stake.rs
@@ -1,5 +1,5 @@
 use crate::utils::sleep_n_slots;
-use log::info;
+use log::{debug, info, warn};
 use solana_client::rpc_client::RpcClient;
 use solana_client::rpc_request::RpcEpochInfo;
 use solana_sdk::genesis_block::GenesisBlock;
@@ -54,12 +54,12 @@ pub fn wait_for_activation(
     }
 
     loop {
-        info!(
+        debug!(
             "Fetching stake history entry for activation epoch ({})...",
             activation_epoch
         );
         if let Some(stake_entry) = stake_activation_epoch_entry(activation_epoch, &rpc_client) {
-            info!("Stake history entry: {:?}", &stake_entry);
+            debug!("Stake history entry: {:?}", &stake_entry);
             let num_epochs = epochs_until_activation(stake_entry, stake_config);
             let warmed_up_epoch = activation_epoch + num_epochs;
             if warmed_up_epoch > current_epoch {
@@ -74,7 +74,7 @@ pub fn wait_for_activation(
             }
             break;
         } else {
-            info!(
+            warn!(
                 "Failed to fetch stake history entry activation epoch: {}",
                 activation_epoch
             );

--- a/ramp-tps/src/stake.rs
+++ b/ramp-tps/src/stake.rs
@@ -1,6 +1,7 @@
 use crate::utils::sleep_n_slots;
 use log::info;
 use solana_client::rpc_client::RpcClient;
+use solana_client::rpc_request::RpcEpochInfo;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::sysvar::stake_history::{self, StakeHistory, StakeHistoryEntry};
 use solana_stake_api::config::Config as StakeConfig;
@@ -33,13 +34,11 @@ fn stake_activation_epoch_entry(
 
 pub fn wait_for_activation(
     activation_epoch: u64,
+    epoch_info: RpcEpochInfo,
     rpc_client: &RpcClient,
     stake_config: &StakeConfig,
     genesis_block: &GenesisBlock,
 ) {
-    info!("Fetching current epoch info...");
-    let epoch_info = rpc_client.get_epoch_info().unwrap();
-    info!("Current epoch info: {:?}", &epoch_info);
     let current_epoch = epoch_info.epoch;
 
     // Sleep until activation_epoch has finished

--- a/ramp-tps/src/utils.rs
+++ b/ramp-tps/src/utils.rs
@@ -1,5 +1,5 @@
 use bzip2::bufread::BzDecoder;
-use log::debug;
+use log::*;
 use solana_netutil::parse_host;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::timing::duration_as_ms;

--- a/ramp-tps/src/utils.rs
+++ b/ramp-tps/src/utils.rs
@@ -1,5 +1,5 @@
 use bzip2::bufread::BzDecoder;
-use log::info;
+use log::debug;
 use solana_netutil::parse_host;
 use solana_sdk::genesis_block::GenesisBlock;
 use solana_sdk::timing::duration_as_ms;
@@ -28,11 +28,11 @@ pub fn sleep_n_slots(num_slots: u64, genesis_block: &GenesisBlock) {
     let mins = secs / 60;
     let hours = mins / 60;
     if hours >= 5 {
-        info!("Sleeping for {} slots ({} hours)", num_slots, hours);
+        debug!("Sleeping for {} slots ({} hours)", num_slots, hours);
     } else if mins >= 5 {
-        info!("Sleeping for {} slots ({} minutes)", num_slots, mins);
+        debug!("Sleeping for {} slots ({} minutes)", num_slots, mins);
     } else if secs > 0 {
-        info!("Sleeping for {} slots ({} seconds)", num_slots, secs);
+        debug!("Sleeping for {} slots ({} seconds)", num_slots, secs);
     }
     sleep(Duration::from_secs(secs));
 }
@@ -48,7 +48,7 @@ pub fn download_genesis(rpc_addr: &SocketAddr, download_path: &Path) -> Result<(
     let archive_path = download_path.join(archive_name);
     let url = format!("http://{}/{}", rpc_addr, archive_name);
     let download_start = Instant::now();
-    info!("Downloading genesis ({})...", url);
+    debug!("Downloading genesis ({})...", url);
 
     let client = reqwest::Client::new();
     let mut response = client
@@ -70,13 +70,13 @@ pub fn download_genesis(rpc_addr: &SocketAddr, download_path: &Path) -> Result<(
     io::copy(&mut response, &mut file)
         .map_err(|err| format!("Unable to write {:?}: {:?}", archive_path, err))?;
 
-    info!(
+    debug!(
         "Downloaded genesis ({} bytes) in {:?}",
         download_size,
         Instant::now().duration_since(download_start),
     );
 
-    info!("Extracting genesis ({:?})...", archive_name);
+    debug!("Extracting genesis ({})...", archive_name);
     let extract_start = Instant::now();
     let tar_bz2 = File::open(&archive_path)
         .map_err(|err| format!("Unable to open {}: {:?}", archive_name, err))?;
@@ -85,7 +85,7 @@ pub fn download_genesis(rpc_addr: &SocketAddr, download_path: &Path) -> Result<(
     archive
         .unpack(download_path)
         .map_err(|err| format!("Unable to unpack {}: {:?}", archive_name, err))?;
-    info!(
+    debug!(
         "Extracted {} in {:?}",
         archive_name,
         Instant::now().duration_since(extract_start)


### PR DESCRIPTION
Runs rounds of `bench-tps` until the cluster fails. Each round linearly increases the transaction count sent by `bench-tps`.

#### Changes
- Log level updates
- Loop rounds indefinitely
- After each round, kill bench-tps and wait for stake to activate
- New cli args:
  * `round`: specify the start round (used for recovery)
  * `round_minutes`: how long to run a round for
  * `stake_activation_epoch`: check that the stake activated in this epoch fully warms up before starting a round (used for recovery)

*(Note: Stake awards implemented here: https://github.com/solana-labs/tour-de-sol/pull/30)*
