### PR TITLE
Rename tps to tx count where appropriate

### DIFF
--- a/README-internal.md
+++ b/README-internal.md
@@ -120,8 +120,8 @@ export SLACK_CHANNEL_ID=
 $ cargo run -p solana-ramp-tps -- -n $NET_VALIDATOR0_IP \
   --net-dir <solana/net> \
   --round-minutes 15 \
-  --tps-baseline 5000 \
-  --tps-increment 5000 \
+  --tx-count-baseline 5000 \
+  --tx-count-increment 5000 \
   --mint-keypair-path <mint_keypair.json>
 ```
 
@@ -140,8 +140,8 @@ $ cargo run -p solana-ramp-tps -- -n $NET_VALIDATOR0_IP \
   --net-dir <solana/net> \
   --round <START ROUND> \
   --round-minutes 15 \
-  --tps-baseline 5000 \
-  --tps-increment 5000 \
+  --tx-count-baseline 5000 \
+  --tx-count-increment 5000 \
   --stake-activation-epoch <LAST STAKE ACTIVATION EPOCH> \
   --mint-keypair-path <mint_keypair.json>
 ```

--- a/bench-tps.sh
+++ b/bench-tps.sh
@@ -12,7 +12,12 @@ if [[ -z $txCount ]]; then
   txCount=1000
 fi
 
-remote=$3
+threadBatchSleepMs=$3
+if [[ -z $threadBatchSleepMs ]]; then
+  threadBatchSleepMs=250
+fi
+
+remote=$4
 if [[ -n $remote ]]; then
   exec > solana/client.log
   exec 2>&1
@@ -40,4 +45,4 @@ solana -u http://$host:8899 -k bench-tps.json balance
 
 export RUST_LOG=solana=info
 solana-bench-tps -i bench-tps.json --tx_count=$txCount \
-  -n $host:8001 -N 2 --sustained --thread-batch-sleep-ms=250
+  -n $host:8001 -N 2 --sustained --thread-batch-sleep-ms=$threadBatchSleepMs

--- a/wrapper-bench-tps.sh
+++ b/wrapper-bench-tps.sh
@@ -7,9 +7,10 @@ tdsDir="$(pwd)"
 netDir=$1
 clientId=$2
 txCount=$3
+threadBatchSleepMs=$4
 
 eval "$("$netDir/gce.sh" info --eval)"
 clientIp="NET_CLIENT${clientId}_IP"
 
 "$netDir/scp.sh" $tdsDir/bench-tps.sh solana@${!clientIp}:.
-"$netDir/ssh.sh" ${!clientIp} ./bench-tps.sh $NET_VALIDATOR0_IP $txCount remote
+"$netDir/ssh.sh" ${!clientIp} ./bench-tps.sh $NET_VALIDATOR0_IP $txCount $threadBatchSleepMs remote


### PR DESCRIPTION
The `bench-tps` client is configured with tx-count, not TPS. In order to clear up potential confusion between the two, report the parameters instead of an approximate TPS.