### PR TITLE
Run bench-tps on validators

### DIFF
--- a/bench-tps.sh
+++ b/bench-tps.sh
@@ -27,11 +27,11 @@ if [[ -n $remote ]]; then
   if [[ $txCount = 0 ]]; then
     exit 0
   fi
+else
+  scp -o "ConnectTimeout=20" -o "BatchMode=yes" \
+    -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" \
+    solana@$host:solana/config/mint-keypair.json .
 fi
-
-scp -o "ConnectTimeout=20" -o "BatchMode=yes" \
-  -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" \
-  solana@$host:solana/config/mint-keypair.json .
 
 solana -u http://$host:8899 -k mint-keypair.json balance --lamports
 

--- a/wrapper-bench-tps.sh
+++ b/wrapper-bench-tps.sh
@@ -9,8 +9,10 @@ clientId=$2
 txCount=$3
 threadBatchSleepMs=$4
 
+validatorId=$((clientId+1))
 eval "$("$netDir/gce.sh" info --eval)"
 clientIp="NET_CLIENT${clientId}_IP"
+validatorIp="NET_VALIDATOR${validatorId}_IP"
 
 "$netDir/scp.sh" $tdsDir/bench-tps.sh solana@${!clientIp}:.
-"$netDir/ssh.sh" ${!clientIp} ./bench-tps.sh $NET_VALIDATOR0_IP $txCount $threadBatchSleepMs remote
+"$netDir/ssh.sh" ${!clientIp} ./bench-tps.sh ${!validatorIp} $txCount $threadBatchSleepMs remote


### PR DESCRIPTION
Once mint-keypairs are scp'd to the idle clients at network start, we no longer limited to running bench-tps against the bootstrap leader node. This is because mint-keypair access is no longer coupled to which RPC host is used

Depends on: https://github.com/solana-labs/solana/pull/6536