### PR TITLE
Improve stake activation logic

### DIFF
--- a/ramp-tps/src/main.rs
+++ b/ramp-tps/src/main.rs
@@ -192,7 +192,7 @@ fn main() {
         debug!("Current epoch info: {:?}", &epoch_info);
         let current_epoch = epoch_info.epoch;
         stake::wait_for_activation(
-            current_epoch + 1,
+            current_epoch,
             epoch_info,
             &rpc_client,
             &stake_config,

--- a/ramp-tps/src/stake.rs
+++ b/ramp-tps/src/stake.rs
@@ -8,7 +8,7 @@ use solana_stake_api::config::Config as StakeConfig;
 use std::thread::sleep;
 use std::time::Duration;
 
-fn epochs_until_activation(mut stake_entry: StakeHistoryEntry, stake_config: &StakeConfig) -> u64 {
+fn calculate_stake_warmup(mut stake_entry: StakeHistoryEntry, stake_config: &StakeConfig) -> u64 {
     let mut epochs = 0;
     loop {
         if (stake_entry.activating as f64 / stake_entry.effective.max(1) as f64) < 0.05 {
@@ -23,25 +23,21 @@ fn epochs_until_activation(mut stake_entry: StakeHistoryEntry, stake_config: &St
     epochs
 }
 
-fn stake_activation_epoch_entry(
-    activation_epoch: u64,
-    rpc_client: &RpcClient,
-) -> Option<StakeHistoryEntry> {
+fn stake_history_entry(epoch: u64, rpc_client: &RpcClient) -> Option<StakeHistoryEntry> {
     let stake_history_account = rpc_client.get_account(&stake_history::id()).ok()?;
     let stake_history = StakeHistory::from_account(&stake_history_account)?;
-    stake_history.get(&activation_epoch).cloned()
+    stake_history.get(&epoch).cloned()
 }
 
 pub fn wait_for_activation(
     activation_epoch: u64,
-    epoch_info: RpcEpochInfo,
+    mut epoch_info: RpcEpochInfo,
     rpc_client: &RpcClient,
     stake_config: &StakeConfig,
     genesis_block: &GenesisBlock,
 ) {
-    let current_epoch = epoch_info.epoch;
-
     // Sleep until activation_epoch has finished
+    let mut current_epoch = epoch_info.epoch;
     let sleep_epochs = (activation_epoch + 1).saturating_sub(current_epoch);
     let slots_per_epoch = genesis_block.epoch_schedule.slots_per_epoch;
     if sleep_epochs > 0 {
@@ -54,29 +50,30 @@ pub fn wait_for_activation(
     }
 
     loop {
+        epoch_info = rpc_client.get_epoch_info().unwrap();
+        current_epoch = epoch_info.epoch;
         debug!(
-            "Fetching stake history entry for activation epoch ({})...",
-            activation_epoch
+            "Fetching stake history entry for epoch: {}...",
+            current_epoch
         );
-        if let Some(stake_entry) = stake_activation_epoch_entry(activation_epoch, &rpc_client) {
+
+        if let Some(stake_entry) = stake_history_entry(current_epoch, &rpc_client) {
             debug!("Stake history entry: {:?}", &stake_entry);
-            let num_epochs = epochs_until_activation(stake_entry, stake_config);
-            let warmed_up_epoch = activation_epoch + num_epochs;
-            if warmed_up_epoch > current_epoch {
-                let epoch_info = rpc_client.get_epoch_info().unwrap();
+            let warm_up_epochs = calculate_stake_warmup(stake_entry, stake_config);
+            if warm_up_epochs > 0 {
                 info!(
                     "Waiting until epoch {} for stake to warmup...",
-                    warmed_up_epoch
+                    current_epoch + warm_up_epochs
                 );
-                let sleep_epochs = warmed_up_epoch - current_epoch;
-                let sleep_slots = sleep_epochs * slots_per_epoch - epoch_info.slot_index;
+                let sleep_slots = warm_up_epochs * slots_per_epoch - epoch_info.slot_index;
                 sleep_n_slots(sleep_slots, genesis_block);
+            } else {
+                break;
             }
-            break;
         } else {
             warn!(
-                "Failed to fetch stake history entry activation epoch: {}",
-                activation_epoch
+                "Failed to fetch stake history entry for epoch: {}",
+                current_epoch
             );
             sleep(Duration::from_secs(5));
         }


### PR DESCRIPTION
- Fix off by one error when calling `wait_for_activation`. Stake is activated in the current epoch, so only need to wait for it to finish to see the stake schedule
- Handle the case where additional stake was activated since we last checked (double check that 95% of stake is active before starting next round)