### PR TITLE
Buffer notifications to avoid Discord rate limits

### DIFF
--- a/ramp-tps/src/main.rs
+++ b/ramp-tps/src/main.rs
@@ -49,7 +49,7 @@ fn gift_for_round(tps_round: u32, initial_balance: u64) -> u64 {
 fn main() {
     solana_logger::setup_with_filter("solana=debug");
     solana_metrics::set_panic_hook("ramp-tps");
-    let notifier = notifier::Notifier::new();
+    let mut notifier = notifier::Notifier::new();
 
     let matches = App::new(crate_name!())
         .about(crate_description!())
@@ -302,13 +302,14 @@ fn main() {
             ("validators", remaining_voters.len(), i64)
         );
 
-        notifier.notify(&format!(
+        notifier.buffer(format!(
             "There are {} validators present:",
             remaining_voters.len()
         ));
         for (node_pubkey, _) in remaining_voters {
-            notifier.notify(&format!("* {}", pubkey_to_keybase(&node_pubkey)));
+            notifier.buffer(format!("* {}", pubkey_to_keybase(&node_pubkey)));
         }
+        notifier.flush();
 
         let client_tx_count = tx_count / NUM_BENCH_CLIENTS as u64;
         notifier.notify(&format!(
@@ -391,7 +392,7 @@ fn main() {
             &mint_keypair,
             remaining_voters,
             next_gift,
-            &notifier,
+            &mut notifier,
         );
 
         datapoint_info!(

--- a/ramp-tps/src/notifier.rs
+++ b/ramp-tps/src/notifier.rs
@@ -8,6 +8,7 @@ use std::env;
 ///   2) Notify Slack channel if Slack is configured
 ///   3) Notify Discord channel if Discord is configured
 pub struct Notifier {
+    buffer: Vec<String>,
     client: Client,
     discord_webhook: Option<String>,
     slack_webhook: Option<String>,
@@ -26,6 +27,7 @@ impl Notifier {
             })
             .ok();
         Notifier {
+            buffer: Vec::new(),
             client: Client::new(),
             discord_webhook,
             slack_webhook,
@@ -46,6 +48,15 @@ impl Notifier {
                 warn!("Failed to send Slack message: {:?}", err);
             }
         }
+    }
+
+    pub fn buffer(&mut self, msg: String) {
+        self.buffer.push(msg);
+    }
+
+    pub fn flush(&mut self) {
+        self.notify(&self.buffer.join("\n"));
+        self.buffer.clear();
     }
 
     pub fn notify(&self, msg: &str) {

--- a/ramp-tps/src/voters.rs
+++ b/ramp-tps/src/voters.rs
@@ -36,7 +36,7 @@ pub fn award_stake(
     mint_keypair: &Keypair,
     voters: Vec<(String, Pubkey)>,
     sol_gift: u64,
-    notifier: &crate::notifier::Notifier,
+    notifier: &mut crate::notifier::Notifier,
 ) {
     let recent_blockhash = rpc_client.get_recent_blockhash().unwrap().0;
     for (node_pubkey, vote_account_pubkey) in voters {
@@ -56,12 +56,13 @@ pub fn award_stake(
         if let Err(err) = rpc_client
             .send_and_confirm_transaction(&mut transaction, &[mint_keypair, &stake_account_keypair])
         {
-            notifier.notify(&format!(
+            notifier.buffer(format!(
                 "Failed to delegate {} SOL to {}: {}",
                 sol_gift, node_pubkey, err
             ));
         } else {
-            notifier.notify(&format!("Delegated {} SOL to {}", sol_gift, node_pubkey));
+            notifier.buffer(format!("Delegated {} SOL to {}", sol_gift, node_pubkey));
         }
     }
+    notifier.flush();
 }


### PR DESCRIPTION
Discord has dynamic rate limiting which is currently about 5 requests per second. This causes problems when we send a separate notification for each validator.