### PR TITLE
Record the remaining validators for each round

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /mint-keypair.json
 target
 .tmp
+results.yml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2372,6 +2372,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-client 0.20.0 (git+https://github.com/solana-labs/solana?tag=v0.20.0)",

--- a/ramp-tps/Cargo.toml
+++ b/ramp-tps/Cargo.toml
@@ -13,6 +13,7 @@ bzip2 = "0.3.3"
 clap = "2.33.0"
 log = "0.4.8"
 reqwest = { version = "0.9.22", default-features = false }
+serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8.11"
 solana-client = { git = "https://github.com/solana-labs/solana", tag = "v0.20.0" }

--- a/ramp-tps/src/results.rs
+++ b/ramp-tps/src/results.rs
@@ -1,0 +1,101 @@
+use log::*;
+use serde::{Serialize, Serializer};
+use solana_sdk::pubkey::Pubkey;
+use std::{
+    collections::{BTreeMap, HashMap},
+    error::Error,
+    fs::File,
+    io::ErrorKind,
+    process::exit,
+    str::FromStr,
+};
+
+const ROUND_KEY_PREFIX: &str = "round-";
+
+#[derive(Eq, PartialEq, Ord, PartialOrd)]
+struct Round(u32);
+
+impl Serialize for Round {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}{}", ROUND_KEY_PREFIX, self.0))
+    }
+}
+
+pub struct Results {
+    file_path: String,
+    results: BTreeMap<Round, Vec<String>>,
+}
+
+impl Results {
+    /// Keep any result entries which occurred before the starting round.
+    pub fn new(
+        file_path: String,
+        mut previous_results: HashMap<String, Vec<String>>,
+        start_round: u32,
+    ) -> Self {
+        let mut results: BTreeMap<Round, Vec<String>> = BTreeMap::new();
+        previous_results.drain().for_each(|(key, value)| {
+            if key.starts_with(ROUND_KEY_PREFIX) {
+                let round_str = &key[ROUND_KEY_PREFIX.len()..];
+                dbg!(round_str);
+                if let Ok(round) = u32::from_str(round_str) {
+                    if round < start_round {
+                        results.insert(Round(round), value);
+                    }
+                }
+            }
+        });
+
+        Results { file_path, results }
+    }
+
+    // Reads the previous results file and if it exists, parses the contents
+    pub fn read(file_path: &str) -> HashMap<String, Vec<String>> {
+        match File::open(file_path) {
+            Ok(file) => serde_yaml::from_reader(&file)
+                .map_err(|err| {
+                    warn!("Failed to recover previous results: {}", err);
+                })
+                .unwrap_or_default(),
+            Err(err) => match err.kind() {
+                ErrorKind::NotFound => {
+                    // Check that we can write to this file
+                    File::create(file_path).unwrap_or_else(|err| {
+                        eprintln!(
+                            "Error: Unable to create --results-file {}: {}",
+                            file_path, err
+                        );
+                        exit(1);
+                    });
+                    HashMap::new()
+                }
+                err => {
+                    eprintln!(
+                        "Error: Unable to open --results-file {}: {:?}",
+                        file_path, err
+                    );
+                    exit(1);
+                }
+            },
+        }
+    }
+
+    /// Record the remaining validators after each TPS round
+    pub fn record(
+        &mut self,
+        round: u32,
+        validators: &[(String, Pubkey)],
+    ) -> Result<(), Box<dyn Error>> {
+        self.results.insert(
+            Round(round),
+            validators.iter().map(|v| v.0.clone()).collect(),
+        );
+
+        let file = File::create(&self.file_path)?;
+        serde_yaml::to_writer(&file, &self.results)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/tour-de-sol/issues/43

* Records the validators after each round
* Will not overwrite rounds which are before the configured starting round

Sample file:
```
---
round-1:
  - 5DZ5LfdjkxESDBv6FdnoLWPxiMN1p1FCrQmmGnj9vYTR
  - BQuJPbCunGVeKXEas8McnkPwLSDBpUiDzDYvaCgo77k
  - CmmSkk6Nzv4z9YXwGsXRuzJ824uwn3KqAWM8a5jC2Znt
  - Ep3pKQyHSuwTXDtuuFdYiMba56h5L2rE3DxvCvhYvmpD
```

(*It will include keybase names when present*)