### PR TITLE
Fix CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+rust: 1.39.0
 cache: cargo
 script:
   - rustup component add rustfmt


### PR DESCRIPTION
**Problem:**

CI fails with "error: failed to download `elfkit v0.0.6`". (#54)

**Changes:**

Specify rust version 1.39 in the `.travis.yml`

Fixes #54 