### PR TITLE
Use recent blockhash for each stake reward transaction

### DIFF
--- a/ramp-tps/src/voters.rs
+++ b/ramp-tps/src/voters.rs
@@ -38,9 +38,13 @@ pub fn award_stake(
     sol_gift: u64,
     notifier: &mut crate::notifier::Notifier,
 ) {
-    let recent_blockhash = rpc_client.get_recent_blockhash().unwrap().0;
     for (node_pubkey, vote_account_pubkey) in voters {
         let stake_account_keypair = Keypair::new();
+        let recent_blockhash = loop {
+            if let Ok(response) = rpc_client.get_recent_blockhash() {
+                break response.0;
+            }
+        };
         let mut transaction = Transaction::new_signed_instructions(
             &[faucet_keypair, &stake_account_keypair],
             stake_instruction::create_stake_account_and_delegate_stake(


### PR DESCRIPTION
#### Problem
Sending and confirming transactions can now take > 30s with the default commitment level causing the blockhash to be too old when iterating through the later validators for stake rewards

#### Solution
Use a fresh blockhash for every stake reward transaction