### PR TITLE
Sample TPS and report results after each round

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ name = "backtrace-sys"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -259,7 +259,7 @@ name = "bzip2-sys"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.46"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -341,7 +341,7 @@ name = "clear_on_drop"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -429,6 +429,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_affinity"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +457,14 @@ dependencies = [
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread-scoped 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1072,6 +1091,35 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "jemalloc-ctl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1175,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-pubsub"
+version = "14.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jsonrpc-server-utils"
 version = "14.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,6 +1198,19 @@ dependencies = [
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jsonrpc-ws-server"
+version = "14.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-server-utils 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ws 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1159,6 +1231,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,7 +1245,7 @@ name = "libloading"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1178,7 +1255,7 @@ version = "6.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.49.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1279,6 +1356,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mio-uds"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,7 +1403,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1327,7 +1415,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1464,6 +1552,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "paste-impl 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1622,16 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1825,7 +1943,7 @@ name = "ring"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1991,6 +2109,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sha2"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,6 +2194,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-bpf-loader-program"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-logger 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "solana-budget-api"
 version = "0.20.5"
 source = "git+https://github.com/solana-labs/solana?rev=v0.20#a0231f3d87c35ad0da24856f1ad3f2be298d5975"
@@ -2088,6 +2232,29 @@ dependencies = [
  "solana-budget-api 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
  "solana-logger 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
  "solana-sdk 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
+]
+
+[[package]]
+name = "solana-budget-program"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+]
+
+[[package]]
+name = "solana-chacha-sys"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2217,13 +2384,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-core"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core_affinity 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemalloc-ctl 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-http-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-pubsub 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-ws-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-budget-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-chacha-sys 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-clap-utils 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-client 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-drone 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-ledger 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-logger 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-measure 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-merkle-tree 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-metrics 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-net-utils 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-perf 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-rayon-threadlimit 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-reed-solomon-erasure 4.0.1-3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-runtime 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-stake-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-storage-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-vote-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-vote-signer 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "symlink 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "solana-crate-features"
 version = "0.20.5"
 source = "git+https://github.com/solana-labs/solana?rev=v0.20#a0231f3d87c35ad0da24856f1ad3f2be298d5975"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2247,7 +2477,7 @@ source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2279,6 +2509,26 @@ dependencies = [
  "solana-logger 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
  "solana-metrics 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
  "solana-sdk 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-drone"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-logger 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-metrics 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2322,6 +2572,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-exchange-program"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-logger 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-metrics 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+]
+
+[[package]]
 name = "solana-genesis-programs"
 version = "0.20.5"
 source = "git+https://github.com/solana-labs/solana?rev=v0.20#a0231f3d87c35ad0da24856f1ad3f2be298d5975"
@@ -2345,6 +2609,24 @@ dependencies = [
  "solana-vest-program 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
  "solana-vote-api 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
  "solana-vote-program 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
+]
+
+[[package]]
+name = "solana-genesis-programs"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-bpf-loader-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-budget-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-config-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-exchange-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-runtime 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-stake-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-storage-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-vest-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-vote-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
 ]
 
 [[package]]
@@ -2387,6 +2669,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-ledger"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dir-diff 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dlopen 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dlopen_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-client 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-genesis-programs 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-logger 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-measure 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-merkle-tree 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-metrics 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-perf 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-rayon-threadlimit 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-reed-solomon-erasure 4.0.1-3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-runtime 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-stake-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-vote-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "solana-logger"
 version = "0.20.5"
 source = "git+https://github.com/solana-labs/solana?rev=v0.20#a0231f3d87c35ad0da24856f1ad3f2be298d5975"
@@ -2415,11 +2741,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-measure"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+]
+
+[[package]]
 name = "solana-merkle-tree"
 version = "0.20.5"
 source = "git+https://github.com/solana-labs/solana?rev=v0.20#a0231f3d87c35ad0da24856f1ad3f2be298d5975"
 dependencies = [
  "solana-sdk 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
+]
+
+[[package]]
+name = "solana-merkle-tree"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
 ]
 
 [[package]]
@@ -2488,6 +2830,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-perf"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dlopen 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dlopen_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-budget-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-logger 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-metrics 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-rayon-threadlimit 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+]
+
+[[package]]
 name = "solana-ramp-tps"
 version = "1.0.0"
 dependencies = [
@@ -2499,6 +2862,7 @@ dependencies = [
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "solana-client 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-core 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
  "solana-logger 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
  "solana-metrics 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
  "solana-net-utils 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
@@ -2517,11 +2881,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-rayon-threadlimit"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "solana-reed-solomon-erasure"
 version = "4.0.1-3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2559,6 +2932,40 @@ dependencies = [
  "solana-storage-api 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
  "solana-vote-api 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
  "solana-vote-program 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
+ "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "solana-runtime"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bv 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-bpf-loader-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-logger 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-measure 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-metrics 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-rayon-threadlimit 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-stake-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-storage-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-vote-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
  "sys-info 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2703,6 +3110,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-storage-program"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-logger 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+]
+
+[[package]]
 name = "solana-tds-winner-tool"
 version = "1.0.0"
 dependencies = [
@@ -2742,6 +3165,22 @@ dependencies = [
  "solana-logger 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
  "solana-sdk 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
  "solana-vest-api 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)",
+]
+
+[[package]]
+name = "solana-vest-program"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-config-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
 ]
 
 [[package]]
@@ -2805,6 +3244,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-vote-signer"
+version = "0.21.0"
+source = "git+https://github.com/solana-labs/solana?tag=v0.21.0#de6cf6b7e321574e69cfa645c8907251659082aa"
+dependencies = [
+ "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-http-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "solana-clap-utils 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-metrics 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+ "solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)",
+]
+
+[[package]]
 name = "solana_rbpf"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2850,6 +3307,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "subtle"
 version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2906,7 +3368,7 @@ name = "sys-info"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3500,6 +3962,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ws"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3561,7 +4040,7 @@ dependencies = [
 "checksum bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
-"checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
+"checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
 "checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
@@ -3576,8 +4055,10 @@ dependencies = [
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
+"checksum core_affinity 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6d162c6e463c31dbf78fefa99d042156c1c74d404e299cfe3df2923cb857595b"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum criterion-stats 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "387df94cb74ada1b33e10ce034bb0d9360cc73edb5063e7d7d4120a40ee1c9d2"
+"checksum crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
@@ -3645,14 +4126,20 @@ dependencies = [
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum jemalloc-ctl 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c502a5ff9dd2924f1ed32ba96e3b65735d837b4bfd978d3161b1702e66aca4b7"
+"checksum jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+"checksum jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
 "checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 "checksum js-sys 0.3.29 (registry+https://github.com/rust-lang/crates.io-index)" = "5061eb59a5afd4f6ff96dc565963e4e2737b915d070233cb26b88e3f58af41b4"
 "checksum jsonrpc-core 14.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "34651edf3417637cc45e70ed0182ecfa9ced0b7e8131805fccf7400d989845ca"
 "checksum jsonrpc-derive 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
 "checksum jsonrpc-http-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2d83d348120edee487c560b7cdd2565055d61cda053aa0d0ef0f8b6a18429048"
+"checksum jsonrpc-pubsub 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3453625f0f0f5cd6d6776d389d73b7d70fcc98620b7cbb1cbbb1f6a36e95f39a"
 "checksum jsonrpc-server-utils 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "95b7635e618a0edbbe0d2a2bbbc69874277c49383fcf6c3c0414491cfb517d22"
+"checksum jsonrpc-ws-server 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b34faa167c3ac9705aeecb986c0da6056529f348425dbe0441db60a2c4cc41d1"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum librocksdb-sys 6.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0a0785e816e1e11e7599388a492c61ef80ddc2afc91e313e61662cce537809be"
@@ -3668,6 +4155,7 @@ dependencies = [
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum miniz_oxide 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "304f66c19be2afa56530fa7c39796192eef38618da8d19df725ad7c6d6b2aaae"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
+"checksum mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
@@ -3688,6 +4176,8 @@ dependencies = [
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
+"checksum paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "423a519e1c6e828f1e73b720f9d9ed2fa643dce8a7737fb43235ce0b41eeaa49"
+"checksum paste-impl 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4214c9e912ef61bf42b81ba9a47e8aad1b2ffaf739ab162bf96d1e011f54e6c5"
 "checksum pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
@@ -3696,6 +4186,7 @@ dependencies = [
 "checksum pretty-hex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be91bcc43e73799dc46a6c194a55e7aae1d86cc867c860fd4a436019af21bd8c"
 "checksum pretty_env_logger 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8d1e63042e889b85228620629b51c011d380eed2c7e0015f8a644def280c28"
 "checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
+"checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum publicsuffix 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9bf259a81de2b2eb9850ec990ec78e6a25319715584fd7652b9b26f96fcb1510"
@@ -3747,6 +4238,7 @@ dependencies = [
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 "checksum serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)" = "691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35"
+"checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
@@ -3755,8 +4247,11 @@ dependencies = [
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum solana-bpf-loader-api 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-bpf-loader-program 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-bpf-loader-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-budget-api 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-budget-program 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-budget-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
+"checksum solana-chacha-sys 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-clap-utils 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-cli 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-client 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
@@ -3764,25 +4259,35 @@ dependencies = [
 "checksum solana-config-api 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-config-program 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-config-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
+"checksum solana-core 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-crate-features 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-crate-features 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-drone 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-drone 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-ed25519-dalek 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1c21f9d5aa62959872194dfd086feb4e8efec1c2589d27e6a0339904759e99fc"
 "checksum solana-exchange-api 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-exchange-program 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-exchange-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-genesis-programs 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-genesis-programs 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-ledger 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-ledger 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-logger 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-logger 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-measure 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-measure 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-merkle-tree 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-merkle-tree 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-metrics 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-metrics 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-net-utils 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-netutil 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-perf 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-rayon-threadlimit 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-rayon-threadlimit 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-reed-solomon-erasure 4.0.1-3 (registry+https://github.com/rust-lang/crates.io-index)" = "d5b3ab3f4dd12af687a7d0d0ee73299cbc06ed3aada42dccac26fe243e73399e"
 "checksum solana-runtime 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-runtime 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-sdk 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-sdk 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-stake-api 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
@@ -3790,12 +4295,15 @@ dependencies = [
 "checksum solana-stake-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-storage-api 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-storage-program 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-storage-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-vest-api 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-vest-program 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-vest-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-vote-api 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-vote-program 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
 "checksum solana-vote-program 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana-vote-signer 0.20.5 (git+https://github.com/solana-labs/solana?rev=v0.20)" = "<none>"
+"checksum solana-vote-signer 0.21.0 (git+https://github.com/solana-labs/solana?tag=v0.21.0)" = "<none>"
 "checksum solana_rbpf 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "cb45776e861c7a71ed3ccb629c076889dc91a9ba7c1e58e44f8c7b9f916f07c9"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
@@ -3803,6 +4311,7 @@ dependencies = [
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab3af2eb31c42e8f0ccf43548232556c42737e01a96db6e1777b0be108e79799"
+"checksum symlink 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
@@ -3874,6 +4383,7 @@ dependencies = [
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 "checksum winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+"checksum ws 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a2c47b5798ccc774ffb93ff536aec7c4275d722fd9c740c83cdd1af1f2d94"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 "checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"

--- a/ramp-tps/Cargo.toml
+++ b/ramp-tps/Cargo.toml
@@ -16,6 +16,7 @@ reqwest = { version = "0.9.22", default-features = false }
 serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8.11"
+solana-core = { git = "https://github.com/solana-labs/solana", tag = "v0.21.0" }
 solana-client = { git = "https://github.com/solana-labs/solana", tag = "v0.21.0" }
 solana-logger = { git = "https://github.com/solana-labs/solana", tag = "v0.21.0" }
 solana-metrics = { git = "https://github.com/solana-labs/solana", tag = "v0.21.0" }

--- a/ramp-tps/src/tps.rs
+++ b/ramp-tps/src/tps.rs
@@ -1,0 +1,71 @@
+use crate::notifier::Notifier;
+use log::*;
+use solana_client::perf_utils::{sample_txs, SampleStats};
+use solana_client::thin_client::ThinClient;
+use solana_sdk::timing::duration_as_s;
+use std::{
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, RwLock,
+    },
+    thread::{Builder, JoinHandle},
+};
+
+pub struct Sampler {
+    client: Arc<ThinClient>,
+    exit_signal: Arc<AtomicBool>,
+    maxes: Arc<RwLock<Vec<(String, SampleStats)>>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Sampler {
+    pub fn new(rpc_addr: &SocketAddr) -> Self {
+        let (_, dummy_socket) = solana_net_utils::bind_in_range((8000, 10_000)).unwrap();
+        let dummy_tpu_addr = *rpc_addr;
+        let client = Arc::new(ThinClient::new(*rpc_addr, dummy_tpu_addr, dummy_socket));
+
+        Self {
+            client,
+            exit_signal: Arc::new(AtomicBool::new(false)),
+            maxes: Arc::new(RwLock::new(Vec::new())),
+            handle: None,
+        }
+    }
+
+    // Setup a thread to sample every period and
+    // collect the max transaction rate and total tx count seen
+    pub fn start_sampling_thread(&mut self) {
+        // Reset
+        self.exit_signal.store(false, Ordering::Relaxed);
+        self.maxes.write().unwrap().clear();
+
+        let sample_period = 5; // in seconds
+        info!("Sampling TPS every {} seconds...", sample_period);
+        let exit_signal = self.exit_signal.clone();
+        let maxes = self.maxes.clone();
+        let client = self.client.clone();
+        let handle = Builder::new()
+            .name("solana-client-sample".to_string())
+            .spawn(move || {
+                sample_txs(&exit_signal, &maxes, sample_period, &client);
+            })
+            .unwrap();
+
+        self.handle = Some(handle);
+    }
+
+    pub fn stop_sampling_thread(&mut self) {
+        self.exit_signal.store(true, Ordering::Relaxed);
+        self.handle.take().unwrap().join().unwrap();
+    }
+
+    pub fn report_results(&self, notifier: &Notifier) {
+        let SampleStats { tps, elapsed, txs } = self.maxes.read().unwrap()[0].1;
+        let avg_tps = txs as f32 / duration_as_s(&elapsed);
+        notifier.notify(&format!(
+            "Highest TPS: {:.0}, Average TPS: {:.0}",
+            tps, avg_tps
+        ));
+    }
+}


### PR DESCRIPTION
#### Problem
There isn't much visibility into the performance of the cluster after each TPS round except for using the metrics dashboard.

#### Changes
- Wait 30s for bench-tps to warmup before starting round
- Start a TPS sampling thread for the duration of the round.
- Exclusively use the RPC entrypoint for sampling.
- Notify the max tps and avg tps metrics via webhooks