### PR TITLE
Retry stake delegation until success

### DIFF
--- a/ramp-tps/src/voters.rs
+++ b/ramp-tps/src/voters.rs
@@ -1,12 +1,17 @@
+use crate::notifier::Notifier;
 use log::*;
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::native_token::sol_to_lamports;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::{Keypair, KeypairUtil};
-use solana_sdk::transaction::Transaction;
-use solana_stake_program::stake_instruction;
-use solana_stake_program::stake_state::Authorized as StakeAuthorized;
-use std::str::FromStr;
+use solana_sdk::instruction::InstructionError;
+use solana_sdk::{
+    account_utils::State,
+    native_token::sol_to_lamports,
+    pubkey::Pubkey,
+    signature::{Keypair, KeypairUtil},
+    transaction::Transaction,
+};
+use solana_stake_program::stake_state::StakeState;
+use solana_stake_program::{stake_instruction, stake_state::Authorized as StakeAuthorized};
+use std::{str::FromStr, thread::sleep, time::Duration};
 
 pub fn fetch_remaining_voters(rpc_client: &RpcClient) -> Vec<(Pubkey, Pubkey)> {
     match rpc_client.get_vote_accounts() {
@@ -31,20 +36,26 @@ pub fn fetch_remaining_voters(rpc_client: &RpcClient) -> Vec<(Pubkey, Pubkey)> {
     }
 }
 
-pub fn award_stake(
+/// Endlessly retry stake delegation until success
+fn delegate_stake(
     rpc_client: &RpcClient,
     faucet_keypair: &Keypair,
-    voters: Vec<(String, Pubkey)>,
+    vote_account_pubkey: Pubkey,
     sol_gift: u64,
-    notifier: &mut crate::notifier::Notifier,
 ) {
-    for (node_pubkey, vote_account_pubkey) in voters {
-        let stake_account_keypair = Keypair::new();
+    let stake_account_keypair = Keypair::new();
+    let mut retry_count = 0;
+    loop {
         let recent_blockhash = loop {
-            if let Ok(response) = rpc_client.get_recent_blockhash() {
-                break response.0;
+            match rpc_client.get_recent_blockhash() {
+                Ok(response) => break response.0,
+                Err(err) => {
+                    error!("Failed to get recent blockhash: {}", err);
+                    sleep(Duration::from_secs(5));
+                }
             }
         };
+
         let mut transaction = Transaction::new_signed_instructions(
             &[faucet_keypair, &stake_account_keypair],
             stake_instruction::create_stake_account_and_delegate_stake(
@@ -57,17 +68,44 @@ pub fn award_stake(
             recent_blockhash,
         );
 
+        // Check if stake was delegated but just failed to confirm on an earlier attempt
+        if retry_count > 0 {
+            if let Ok(account) = rpc_client.get_account(&stake_account_keypair.pubkey()) {
+                let result: Result<StakeState, InstructionError> = account.state();
+                if result.is_ok() {
+                    break;
+                }
+            }
+        }
+
         if let Err(err) = rpc_client.send_and_confirm_transaction(
             &mut transaction,
             &[faucet_keypair, &stake_account_keypair],
         ) {
-            notifier.buffer(format!(
-                "Failed to delegate {} SOL to {}: {}",
-                sol_gift, node_pubkey, err
-            ));
+            error!(
+                "Failed to delegate stake (retries: {}): {}",
+                retry_count, err
+            );
+            retry_count += 1;
+            sleep(Duration::from_secs(5));
         } else {
-            notifier.buffer(format!("Delegated {} SOL to {}", sol_gift, node_pubkey));
+            break;
         }
+    }
+}
+
+/// Award stake to the surviving validators by delegating stake to their vote account
+pub fn award_stake(
+    rpc_client: &RpcClient,
+    faucet_keypair: &Keypair,
+    voters: Vec<(String, Pubkey)>,
+    sol_gift: u64,
+    notifier: &mut Notifier,
+) {
+    for (node_pubkey, vote_account_pubkey) in voters {
+        info!("Delegate {} SOL to {}", sol_gift, node_pubkey);
+        delegate_stake(rpc_client, faucet_keypair, vote_account_pubkey, sol_gift);
+        notifier.buffer(format!("Delegated {} SOL to {}", sol_gift, node_pubkey));
     }
     notifier.flush();
 }


### PR DESCRIPTION
#### Problem
Stake delegation can fail if the cluster drops a transaction or if the RPC endpoint goes down before the stake delegation transaction can be confirmed

#### Changes
- Loop until stake delegation succeeds
- On retries, check if stake has already been delegated