### PR TITLE
Ramp TPS tuning and fixes

### DIFF
--- a/bench-tps.sh
+++ b/bench-tps.sh
@@ -40,9 +40,10 @@ if [[ ! -f bench-tps.json ]]; then
 fi
 
 solana -u http://$host:8899 -k faucet-keypair.json \
-  pay "$(solana-keygen pubkey bench-tps.json)" 100000 SOL
+  pay "$(solana-keygen pubkey bench-tps.json)" 5000000 SOL
 solana -u http://$host:8899 -k bench-tps.json balance
 
 export RUST_LOG=solana=info
 solana-bench-tps -i bench-tps.json --tx_count=$txCount \
-  -n $host:8001 -N 2 --sustained --thread-batch-sleep-ms=$threadBatchSleepMs
+  -n $host:8001 -N 2 --sustained --thread-batch-sleep-ms=$threadBatchSleepMs \
+  --threads 1

--- a/destake-net-nodes.sh
+++ b/destake-net-nodes.sh
@@ -51,7 +51,7 @@ for i in $(seq 0 $((NET_NUM_VALIDATORS - 1))); do
   else
     (
       set -x
-      solana-keygen new -f -o $i-tds-stake-keypair.json
+      solana-keygen new --no-passphrase -f-o $i-tds-stake-keypair.json
       $solana --keypair $i-identity-keypair.json deactivate-stake $i-stake-keypair.json
       $solana --keypair faucet-keypair.json create-stake-account $i-tds-stake-keypair.json 1 SOL
       $solana --keypair faucet-keypair.json delegate-stake --keypair faucet-keypair.json $i-tds-stake-keypair.json $i-vote-keypair.json

--- a/ramp-tps/src/main.rs
+++ b/ramp-tps/src/main.rs
@@ -32,7 +32,7 @@ const RESULTS_FILE: &str = "results.yml";
 const DEFAULT_TX_COUNT_BASELINE: &str = "5000";
 const DEFAULT_TX_COUNT_INCREMENT: &str = "5000";
 const DEFAULT_TPS_ROUND_MINUTES: &str = "60";
-const THREAD_BATCH_SLEEP_MS: &str = "250";
+const THREAD_BATCH_SLEEP_MS: &str = "1000";
 const DEFAULT_INITIAL_SOL_BALANCE: &str = "1";
 
 // Transaction count increments linearly each round
@@ -359,8 +359,12 @@ fn main() {
                 .unwrap();
         }
 
-        info!("Sleeping 30s to allow bench-tps to warmup");
-        sleep(Duration::from_secs(30));
+        let bench_warmup_secs = 60;
+        info!(
+            "Sleeping {}s to allow bench-tps to warmup",
+            bench_warmup_secs
+        );
+        sleep(Duration::from_secs(bench_warmup_secs));
 
         tps_sampler.start_sampling_thread();
         sleep(round_duration);


### PR DESCRIPTION
- Reduce bench-tps client tx sender threads to `1`
- Increase bench-tps warmup time
- Increase bench-tps initial airdrop
- Fix destake nodes script