### PR TITLE
Award stake based during Ramp TPS to healthy nodes

### DIFF
--- a/ramp-tps/src/results.rs
+++ b/ramp-tps/src/results.rs
@@ -1,6 +1,5 @@
 use log::*;
 use serde::{Serialize, Serializer};
-use solana_sdk::pubkey::Pubkey;
 use std::{
     collections::{BTreeMap, HashMap},
     error::Error,
@@ -84,16 +83,8 @@ impl Results {
     }
 
     /// Record the remaining validators after each TPS round
-    pub fn record(
-        &mut self,
-        round: u32,
-        validators: &[(String, Pubkey)],
-    ) -> Result<(), Box<dyn Error>> {
-        self.results.insert(
-            Round(round),
-            validators.iter().map(|v| v.0.clone()).collect(),
-        );
-
+    pub fn record(&mut self, round: u32, validators: Vec<String>) -> Result<(), Box<dyn Error>> {
+        self.results.insert(Round(round), validators);
         let file = File::create(&self.file_path)?;
         serde_yaml::to_writer(&file, &self.results)?;
         Ok(())

--- a/ramp-tps/src/stake.rs
+++ b/ramp-tps/src/stake.rs
@@ -2,6 +2,7 @@ use crate::{notifier, utils};
 use log::*;
 use solana_client::{rpc_client::RpcClient, rpc_request::RpcEpochInfo};
 use solana_sdk::{
+    clock::Epoch,
     genesis_config::GenesisConfig,
     sysvar::{
         stake_history::{self, StakeHistory, StakeHistoryEntry},
@@ -49,14 +50,15 @@ fn calculate_stake_warmup(mut stake_entry: StakeHistoryEntry, stake_config: &Sta
     epochs
 }
 
-fn stake_history_entry(epoch: u64, rpc_client: &RpcClient) -> Option<StakeHistoryEntry> {
+fn stake_history_entry(epoch: Epoch, rpc_client: &RpcClient) -> Option<StakeHistoryEntry> {
     let stake_history_account = rpc_client.get_account(&stake_history::id()).ok()?;
     let stake_history = StakeHistory::from_account(&stake_history_account)?;
     stake_history.get(&epoch).cloned()
 }
 
-pub fn wait_for_activation(
-    activation_epoch: u64,
+/// Wait until stake warms up and return the current epoch
+pub fn wait_for_warm_up(
+    activation_epoch: Epoch,
     mut epoch_info: RpcEpochInfo,
     rpc_client: &RpcClient,
     stake_config: &StakeConfig,

--- a/ramp-tps/src/voters.rs
+++ b/ramp-tps/src/voters.rs
@@ -1,23 +1,104 @@
 use crate::notifier::Notifier;
+use crate::utils;
 use log::*;
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::instruction::InstructionError;
 use solana_sdk::{
     account_utils::State,
+    clock::Slot,
+    epoch_schedule::EpochSchedule,
+    instruction::InstructionError,
     native_token::sol_to_lamports,
     pubkey::Pubkey,
     signature::{Keypair, KeypairUtil},
     transaction::Transaction,
 };
-use solana_stake_program::stake_state::{Lockup, StakeState};
-use solana_stake_program::{stake_instruction, stake_state::Authorized as StakeAuthorized};
-use std::{str::FromStr, thread::sleep, time::Duration};
+use solana_stake_program::{
+    stake_instruction,
+    stake_state::{Authorized as StakeAuthorized, Lockup, StakeState},
+};
+use std::{
+    collections::{HashMap, HashSet},
+    io,
+    rc::Rc,
+    str::FromStr,
+    thread::sleep,
+    time::Duration,
+};
 
-pub fn fetch_remaining_voters(rpc_client: &RpcClient) -> Vec<(Pubkey, Pubkey)> {
+// The percentage of leader slots that validators complete in order to receive the stake
+// reward at the end of a TPS round.
+const MIN_LEADER_SLOT_PCT: f64 = 80.0;
+
+#[derive(Default)]
+pub struct LeaderRecord {
+    total_slots: u64,
+    missed_slots: u64,
+}
+
+impl LeaderRecord {
+    pub fn completed_slot_pct(&self) -> f64 {
+        if self.total_slots == 0 {
+            0f64
+        } else {
+            let completed_slots = self.total_slots - self.missed_slots;
+            100f64 * completed_slots as f64 / self.total_slots as f64
+        }
+    }
+
+    pub fn healthy(&self) -> bool {
+        self.completed_slot_pct() >= MIN_LEADER_SLOT_PCT
+    }
+}
+
+/// Calculate the leader record for each active validator
+pub fn calculate_leader_records(
+    rpc_client: &RpcClient,
+    epoch_schedule: &EpochSchedule,
+    start_slot: Slot,
+    end_slot: Slot,
+    notifier: &Notifier,
+) -> io::Result<HashMap<Pubkey, LeaderRecord>> {
+    let start_epoch = epoch_schedule.get_epoch(start_slot);
+    let end_epoch = epoch_schedule.get_epoch(end_slot);
+    let confirmed_blocks: HashSet<_> = rpc_client
+        .get_confirmed_blocks(start_slot, Some(end_slot))?
+        .into_iter()
+        .collect();
+
+    let mut leader_records = HashMap::<Pubkey, LeaderRecord>::new();
+    for epoch in start_epoch..=end_epoch {
+        let first_slot_in_epoch = epoch_schedule.get_first_slot_in_epoch(epoch);
+        let start_slot = std::cmp::max(start_slot, first_slot_in_epoch);
+        let last_slot_in_epoch = epoch_schedule.get_last_slot_in_epoch(epoch);
+        let end_slot = std::cmp::min(end_slot, last_slot_in_epoch);
+
+        rpc_client
+            .get_leader_schedule(Some(start_slot))?
+            .unwrap_or_else(|| utils::bail(notifier, "Error: Leader schedule was not found"))
+            .into_iter()
+            .map(|(pk, s)| (Pubkey::from_str(&pk).unwrap(), s))
+            .for_each(|(pubkey, leader_slots)| {
+                let mut record = leader_records.entry(pubkey).or_default();
+                for slot_index in leader_slots.iter() {
+                    let slot = (*slot_index as u64) + first_slot_in_epoch;
+                    if slot >= start_slot && slot <= end_slot {
+                        record.total_slots += 1;
+                        if !confirmed_blocks.contains(&slot) {
+                            record.missed_slots += 1;
+                        }
+                    }
+                }
+            });
+    }
+
+    Ok(leader_records)
+}
+
+pub fn fetch_active_validators(rpc_client: &RpcClient) -> HashMap<Pubkey, Pubkey> {
     match rpc_client.get_vote_accounts() {
         Err(err) => {
             warn!("Failed to get_vote_accounts(): {}", err);
-            vec![]
+            HashMap::new()
         }
         Ok(vote_accounts) => vote_accounts
             .current
@@ -40,7 +121,7 @@ pub fn fetch_remaining_voters(rpc_client: &RpcClient) -> Vec<(Pubkey, Pubkey)> {
 fn delegate_stake(
     rpc_client: &RpcClient,
     faucet_keypair: &Keypair,
-    vote_account_pubkey: Pubkey,
+    vote_account_pubkey: &Pubkey,
     sol_gift: u64,
 ) {
     let stake_account_keypair = Keypair::new();
@@ -95,11 +176,62 @@ fn delegate_stake(
     }
 }
 
+/// Announce validator status leader slot performance
+pub fn announce_results(
+    starting_validators: &HashMap<Pubkey, Pubkey>,
+    remaining_validators: &HashMap<Pubkey, Pubkey>,
+    pubkey_to_keybase: Rc<dyn Fn(&Pubkey) -> String>,
+    leader_records: &HashMap<Pubkey, LeaderRecord>,
+    notifier: &mut Notifier,
+) {
+    let buffer_records = |keys: Vec<&Pubkey>, notifier: &mut Notifier| {
+        if keys.is_empty() {
+            notifier.buffer("* NA".to_string());
+            return;
+        }
+
+        for pubkey in keys {
+            let name = pubkey_to_keybase(pubkey);
+            if let Some(record) = leader_records.get(pubkey) {
+                notifier.buffer(format!(
+                    "* {} ({:.1}% leader efficiency)",
+                    name,
+                    record.completed_slot_pct()
+                ));
+            }
+        }
+    };
+
+    let healthy: Vec<_> = remaining_validators
+        .keys()
+        .filter(|k| leader_records.get(k).map(|r| r.healthy()).unwrap_or(false))
+        .collect();
+
+    let unhealthy: Vec<_> = remaining_validators
+        .keys()
+        .filter(|k| leader_records.get(k).map(|r| !r.healthy()).unwrap_or(true))
+        .collect();
+
+    let inactive: Vec<_> = starting_validators
+        .keys()
+        .filter(|k| !remaining_validators.contains_key(k))
+        .collect();
+
+    notifier.buffer("Healthy Validators:".to_string());
+    buffer_records(healthy, notifier);
+    notifier.buffer("Unhealthy Validators:".to_string());
+    buffer_records(unhealthy, notifier);
+    notifier.buffer("Inactive Validators:".to_string());
+    buffer_records(inactive, notifier);
+
+    notifier.flush();
+}
+
 /// Award stake to the surviving validators by delegating stake to their vote account
 pub fn award_stake(
     rpc_client: &RpcClient,
     faucet_keypair: &Keypair,
-    voters: Vec<(String, Pubkey)>,
+    voters: Vec<(String, &Pubkey)>,
     sol_gift: u64,
     notifier: &mut Notifier,
 ) {


### PR DESCRIPTION
Fixes: https://github.com/solana-labs/tour-de-sol/issues/67

#### Problem
Ramp TPS currently awards stake after each round to all validators that are still standing, regardless of whether they are actually producing blocks during their leader slots. This means that slow, unhealthy nodes will continue to share a portion of stake with healthy nodes, preventing the cluster from reaching its max potential TPS.

#### Changes
* Only delegate stake to validators which produce at least 80% of their leader blocks
* Calculate leader records for each validator by querying the RPC endpoints for leader schedule and confirmed blocks.
* Announce the leader block production rate for each node and whether each node is considered "Healthy", "Unhealthy", or "Inactive"

#### Output

```
Healthy Validators:
* FXPSWXpeRh2U1CvWTE7ZPRnxPrbPwCcbpYxZdBvo26o6 (80.0% leader efficiency)
* 9GZi92WpZKbkwwix5hg3yUMEE25Fi7PPu1zKSxeJpoeM (92.1% leader efficiency)
* 5ff9PrQJkYRHyGNVciCu57Vkf6XntH4hoRjUof4GoQV4 (91.7% leader efficiency)
Unhealthy Validators:
* NA
Inactive Validators:
* NA
```
